### PR TITLE
Fix Docker healthcheck issues in staging environment

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -16,7 +16,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 60s
     networks:
       - umt-network
 
@@ -35,8 +35,9 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ping"]
       interval: 60s
-      timeout: 5s
-      retries: 3
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     depends_on:
       - postgres
       - redis

--- a/docker/api-gateway.dockerfile
+++ b/docker/api-gateway.dockerfile
@@ -4,7 +4,12 @@ WORKDIR /app
 
 COPY src/api/staging_main.py .
 
-RUN pip install fastapi uvicorn
+# Install curl for healthchecks and pip packages
+RUN apt-get update && \
+    apt-get install -y curl && \
+    pip install fastapi uvicorn && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV ENVIRONMENT=staging
 

--- a/monitoring/Dockerfile.health-api
+++ b/monitoring/Dockerfile.health-api
@@ -2,7 +2,12 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
-RUN pip install fastapi uvicorn psutil requests
+# Install curl for healthchecks and pip packages
+RUN apt-get update && \
+    apt-get install -y curl && \
+    pip install fastapi uvicorn psutil requests && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY monitoring/health_api.py /app/
 


### PR DESCRIPTION
## What's Changed
This PR addresses the issues with unhealthy API containers in the staging environment:

1. **API Gateway Container**: 
   - Added curl to the Dockerfile for healthcheck support
   - Increased the healthcheck start period to give more time for the service to initialize

2. **Health API Container**:
   - Added curl to the Dockerfile for healthcheck support
   - Increased healthcheck timeout and retries
   - Increased start period to allow more time for dependent services

## How to Test
1. Pull this branch
2. Run `docker-compose -f docker-compose.staging.yml down --remove-orphans`
3. Run `docker-compose -f docker-compose.staging.yml up -d`
4. Check container health with `docker-compose -f docker-compose.staging.yml ps`

All containers should now show as healthy after the startup period.